### PR TITLE
Customizable CharsetDecoder in AsyncCharConsumer

### DIFF
--- a/httpasyncclient/src/main/java/org/apache/http/nio/client/methods/AsyncCharConsumer.java
+++ b/httpasyncclient/src/main/java/org/apache/http/nio/client/methods/AsyncCharConsumer.java
@@ -78,15 +78,29 @@ public abstract class AsyncCharConsumer<T> extends AbstractAsyncResponseConsumer
     protected abstract void onCharReceived(
             CharBuffer buf, IOControl ioctrl) throws IOException;
 
+    /**
+     * Invoked to create a @{link CharsetDecoder} for contentType.
+     * This allows to use different default charsets for different content
+     * types and set appropriate coding error actions.
+     *
+     * @param contentType response Content-Type or null if not specified.
+     * @return content decoder.
+     */
+    protected CharsetDecoder createDecoder(final ContentType contentType) {
+        final Charset charset;
+        if (contentType == null || contentType.getCharset() == null) {
+            charset = HTTP.DEF_CONTENT_CHARSET;
+        } else {
+            charset = contentType.getCharset();
+        }
+        return charset.newDecoder();
+    }
+
     @Override
     protected final void onEntityEnclosed(
             final HttpEntity entity, final ContentType contentType) throws IOException {
         this.contentType = contentType != null ? contentType : ContentType.DEFAULT_TEXT;
-        Charset charset = this.contentType.getCharset();
-        if (charset == null) {
-            charset = HTTP.DEF_CONTENT_CHARSET;
-        }
-        this.chardecoder = charset.newDecoder();
+        this.chardecoder = createDecoder(contentType);
     }
 
     @Override


### PR DESCRIPTION
Some servers doesn't specify Content-Type header, while sending response in UTF-8. This change will allow to consume such servers responses properly.
Also, this will allow to specify content-type specific default charset. For example, application/json rfc requires unicode representation, so for json-responses UTF-8 can be used as the default charset.
