### PR TITLE
4.1.2/3

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -46,6 +46,5 @@ mvn apache-rat:check
 
 Execute the following commands in order to generate Javadoc:
 
-mvn install
-mvn javadoc:aggregate
+mvn compile javadoc:aggregate
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache HttpComponents AsyncClient
-Copyright 2010-2016 The Apache Software Foundation
+Copyright 2010-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache HttpComponents AsyncClient
-Copyright 2010-2015 The Apache Software Foundation
+Copyright 2010-2016 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,28 @@
+Release 4.1.3
+-------------------
+
+This is a maintenance release that fixes a number of minor issues discovered since 4.1.2 and upgrades
+HttpCore and HttpClient dependencies.
+
+Changelog
+-------------------
+
+* HttpCore upgraded to version 4.4.6
+
+* HttpClient upgraded to version 4.5.3
+
+* [HTTPASYNC-110] Default exchange handler fails to correctly re-use fully established tunnelled connection
+  leased from the pool when CONNECT request results in 407 over connection that cannot be kept alive.
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+* [HTTPASYNC-116] Correct cancellation of client message exchange.
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+* Fix HttpAsyncMethods#createPost/createPut(URI,byte[],ContentType): set entity to request
+  Contributed by Dmitry Potapov <dpotapov at yandex-team.ru>
+
+
+
 Release 4.1.2
 -------------------
 

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,28 @@
+Release 4.1.2
+-------------------
+
+This is a maintenance release that fixes a number of issues discovered since 4.1.1 and upgrades
+HttpCore and HttpClient dependencies.
+
+Changelog
+-------------------
+
+* HttpCore upgraded to version 4.4.5
+
+* HttpClient upgraded to version 4.5.2
+
+* [HTTPASYNC-105] socketTimeout is not reset back to default after a request that has specific 
+  timeout
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+* [HTTPASYNC-101 CachingHttpAsyncClient to create default HttpContext if none specified
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+* [HTTPASYNC-97] Upgraded HttpClient OSGi dependency to 4.5
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+
+
 Release 4.1.1
 -------------------
 

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -4,6 +4,10 @@ Release 4.1.3
 This is a maintenance release that fixes a number of minor issues discovered since 4.1.2 and upgrades
 HttpCore and HttpClient dependencies.
 
+* [HTTPASYNC-135] HttpAsyncMethods.createHead() methods creates HttpGet objects.
+  Contributed by Mateusz Matela <mateusz dot matela at gmail dot>
+
+
 Changelog
 -------------------
 

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -7,6 +7,10 @@ HttpCore and HttpClient dependencies.
 * [HTTPASYNC-135] HttpAsyncMethods.createHead() methods creates HttpGet objects.
   Contributed by Mateusz Matela <mateusz dot matela at gmail dot>
 
+* HttpCore upgraded to version 4.4.9
+
+* HttpClient upgraded to version 4.5.5
+
 
 Changelog
 -------------------

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,4 +1,4 @@
-Release 4.1.3
+Release 4.1.4
 -------------------
 
 This is a maintenance release that fixes a number of minor issues discovered since 4.1.2 and upgrades
@@ -11,6 +11,10 @@ HttpCore and HttpClient dependencies.
 
 * HttpClient upgraded to version 4.5.5
 
+
+
+Release 4.1.3
+-------------------
 
 Changelog
 -------------------

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,25 @@
+Release 4.1.1
+-------------------
+
+This is a maintenance release that fixes a number of issues discovered since 4.1 and upgrades
+HttpCore and HttpClient dependencies.
+
+Changelog
+-------------------
+
+* HttpCore upgraded to version 4.4.4
+
+* HttpClient upgraded to version 4.5.1
+
+* [HTTPASYNC-92] Fixed osgi bundle imports (added missing 'org.apache.http.ssl')
+  Contributed by Daniel Kulp <dkulp at apache.org>
+
+* HttpAsyncClientBuilder ignores UseSystemProperties setting when initializing SSL context
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+
+
+
 Release 4.1
 -------------------
 

--- a/httpasyncclient-cache/pom.xml
+++ b/httpasyncclient-cache/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.2-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient-cache</artifactId>
   <name>Apache HttpAsyncClient Cache</name>

--- a/httpasyncclient-cache/pom.xml
+++ b/httpasyncclient-cache/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.2-alpha1-SNAPSHOT</version>
+    <version>4.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient-cache</artifactId>
   <name>Apache HttpAsyncClient Cache</name>

--- a/httpasyncclient-cache/pom.xml
+++ b/httpasyncclient-cache/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.2-SNAPSHOT</version>
+    <version>4.1.3-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient-cache</artifactId>
   <name>Apache HttpAsyncClient Cache</name>

--- a/httpasyncclient-cache/pom.xml
+++ b/httpasyncclient-cache/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2-alpha1-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient-cache</artifactId>
   <name>Apache HttpAsyncClient Cache</name>

--- a/httpasyncclient-cache/pom.xml
+++ b/httpasyncclient-cache/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.3-SNAPSHOT</version>
+    <version>4.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient-cache</artifactId>
   <name>Apache HttpAsyncClient Cache</name>

--- a/httpasyncclient-cache/src/main/java/org/apache/http/impl/client/cache/AsynchronousAsyncValidationRequest.java
+++ b/httpasyncclient-cache/src/main/java/org/apache/http/impl/client/cache/AsynchronousAsyncValidationRequest.java
@@ -94,9 +94,9 @@ class AsynchronousAsyncValidationRequest implements Runnable {
             future.get();
         } catch (final ProtocolException pe) {
             this.log.error("ProtocolException thrown during asynchronous revalidation", pe);
-        } catch (ExecutionException e) {
+        } catch (final ExecutionException e) {
             this.log.error("Exception thrown during asynchronous revalidation", e.getCause());
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
         } finally {
             this.parent.markComplete(this.identifier);

--- a/httpasyncclient-cache/src/main/java/org/apache/http/impl/client/cache/CachingHttpAsyncClient.java
+++ b/httpasyncclient-cache/src/main/java/org/apache/http/impl/client/cache/CachingHttpAsyncClient.java
@@ -288,7 +288,7 @@ public class CachingHttpAsyncClient implements HttpAsyncClient {
             final FutureCallback<HttpResponse> futureCallback) {
         final BasicFuture<HttpResponse> future = new BasicFuture<HttpResponse>(futureCallback);
         final HttpRequestWrapper request = HttpRequestWrapper.wrap(originalRequest);
-        final HttpCacheContext clientContext = HttpCacheContext.adapt(context);
+        final HttpCacheContext clientContext = context != null ? HttpCacheContext.adapt(context) : HttpCacheContext.create();
         // default response context
         setResponseStatus(clientContext, CacheResponseStatus.CACHE_MISS);
 

--- a/httpasyncclient-cache/src/main/java/org/apache/http/impl/client/cache/CachingHttpAsyncClient.java
+++ b/httpasyncclient-cache/src/main/java/org/apache/http/impl/client/cache/CachingHttpAsyncClient.java
@@ -48,7 +48,8 @@ import org.apache.http.HttpVersion;
 import org.apache.http.ProtocolException;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.RequestLine;
-import org.apache.http.annotation.ThreadSafe;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.cache.CacheResponseStatus;
 import org.apache.http.client.cache.HeaderConstants;
@@ -76,7 +77,7 @@ import org.apache.http.util.Args;
 import org.apache.http.util.EntityUtils;
 import org.apache.http.util.VersionInfo;
 
-@ThreadSafe // So long as the responseCache implementation is threadsafe
+@Contract(threading = ThreadingBehavior.SAFE) // So long as the responseCache implementation is threadsafe
 public class CachingHttpAsyncClient implements HttpAsyncClient {
 
     private final static boolean SUPPORTS_RANGE_AND_CONTENT_RANGE_HEADERS = false;

--- a/httpasyncclient-cache/src/test/java/org/apache/http/impl/client/cache/CachingHttpAsyncClientExecChain.java
+++ b/httpasyncclient-cache/src/test/java/org/apache/http/impl/client/cache/CachingHttpAsyncClientExecChain.java
@@ -100,21 +100,21 @@ public class CachingHttpAsyncClientExecChain implements ClientExecChain {
         try {
             final Future<HttpResponse> future = client.execute(route.getTargetHost(), request, context, null);
             return Proxies.enhanceResponse(future.get());
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             return null;
-        } catch (ExecutionException e) {
+        } catch (final ExecutionException e) {
             try {
                 throw e.getCause();
-            } catch (IOException ex) {
+            } catch (final IOException ex) {
                 throw ex;
-            } catch (HttpException ex) {
+            } catch (final HttpException ex) {
                 throw ex;
-            } catch (RuntimeException ex) {
+            } catch (final RuntimeException ex) {
                 throw ex;
-            } catch (Error ex) {
+            } catch (final Error ex) {
                 throw ex;
-            } catch (Throwable ex) {
+            } catch (final Throwable ex) {
                 throw new UndeclaredThrowableException(ex);
             }
         }

--- a/httpasyncclient-cache/src/test/java/org/apache/http/impl/client/cache/ClientExecChainAsyncClient.java
+++ b/httpasyncclient-cache/src/test/java/org/apache/http/impl/client/cache/ClientExecChainAsyncClient.java
@@ -111,9 +111,9 @@ public class ClientExecChainAsyncClient extends CloseableHttpAsyncClient {
                     HttpRequestWrapper.wrap(request),
                     HttpClientContext.adapt(context), null);
             future.completed(result);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             future.failed(e);
-        } catch (HttpException e) {
+        } catch (final HttpException e) {
             future.failed(e);
         }
         return future;

--- a/httpasyncclient-osgi/pom.xml
+++ b/httpasyncclient-osgi/pom.xml
@@ -116,7 +116,9 @@
             org.apache.http.impl.cookie;version=${httpclient.osgi.import.version},
             org.apache.http.impl.conn;version=${httpclient.osgi.import.version},
             org.apache.http.impl.client;version=${httpclient.osgi.import.version},
-            org.apache.http.impl.execchain;version=${httpclient.osgi.import.version}
+            org.apache.http.impl.execchain;version=${httpclient.osgi.import.version},
+            org.apache.http.ssl;version=${httpcore.osgi.import.version},
+            *
             </Import-Package>
             <Include-Resource />
             <!-- Stop the JAVA_1_n_HOME variables from being treated as headers by Bnd -->

--- a/httpasyncclient-osgi/pom.xml
+++ b/httpasyncclient-osgi/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2-alpha1-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient-osgi</artifactId>
   <name>Apache HttpAsyncClient OSGi bundle</name>

--- a/httpasyncclient-osgi/pom.xml
+++ b/httpasyncclient-osgi/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.2-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient-osgi</artifactId>
   <name>Apache HttpAsyncClient OSGi bundle</name>

--- a/httpasyncclient-osgi/pom.xml
+++ b/httpasyncclient-osgi/pom.xml
@@ -40,7 +40,7 @@
 
   <properties>
     <httpcore.osgi.import.version>"[4.4.0, 4.5.0)"</httpcore.osgi.import.version>
-    <httpclient.osgi.import.version>"[4.4.0, 4.5.0)"</httpclient.osgi.import.version>
+    <httpclient.osgi.import.version>"[4.5.0, 4.6.0)"</httpclient.osgi.import.version>
     <commons-logging.osgi.import.version>"[1.1.0, 1.2.0)"</commons-logging.osgi.import.version>
   </properties>
 

--- a/httpasyncclient-osgi/pom.xml
+++ b/httpasyncclient-osgi/pom.xml
@@ -41,7 +41,7 @@
   <properties>
     <httpcore.osgi.import.version>"[4.4.0, 4.5.0)"</httpcore.osgi.import.version>
     <httpclient.osgi.import.version>"[4.5.0, 4.6.0)"</httpclient.osgi.import.version>
-    <commons-logging.osgi.import.version>"[1.1.0, 1.2.0)"</commons-logging.osgi.import.version>
+    <commons-logging.osgi.import.version>"[1.1.0, 1.3.0)"</commons-logging.osgi.import.version>
   </properties>
 
   <dependencies>

--- a/httpasyncclient-osgi/pom.xml
+++ b/httpasyncclient-osgi/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.2-SNAPSHOT</version>
+    <version>4.1.3-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient-osgi</artifactId>
   <name>Apache HttpAsyncClient OSGi bundle</name>

--- a/httpasyncclient-osgi/pom.xml
+++ b/httpasyncclient-osgi/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.3-SNAPSHOT</version>
+    <version>4.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient-osgi</artifactId>
   <name>Apache HttpAsyncClient OSGi bundle</name>

--- a/httpasyncclient-osgi/pom.xml
+++ b/httpasyncclient-osgi/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.2-alpha1-SNAPSHOT</version>
+    <version>4.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient-osgi</artifactId>
   <name>Apache HttpAsyncClient OSGi bundle</name>

--- a/httpasyncclient-osgi/pom.xml
+++ b/httpasyncclient-osgi/pom.xml
@@ -107,7 +107,7 @@
             org.apache.http.conn.ssl;version=${httpclient.osgi.import.version},
             org.apache.http.conn.util;version=${httpclient.osgi.import.version},
             org.apache.http.client;version=${httpclient.osgi.import.version},
-            org.apache.http.client.config;version=${httpcore.osgi.import.version},
+            org.apache.http.client.config;version=${httpclient.osgi.import.version},
             org.apache.http.client.methods;version=${httpclient.osgi.import.version},
             org.apache.http.client.params;version=${httpclient.osgi.import.version},
             org.apache.http.client.protocol;version=${httpclient.osgi.import.version},

--- a/httpasyncclient/pom.xml
+++ b/httpasyncclient/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.2-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient</artifactId>
   <name>Apache HttpAsyncClient</name>

--- a/httpasyncclient/pom.xml
+++ b/httpasyncclient/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.2-SNAPSHOT</version>
+    <version>4.1.3-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient</artifactId>
   <name>Apache HttpAsyncClient</name>

--- a/httpasyncclient/pom.xml
+++ b/httpasyncclient/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2-alpha1-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient</artifactId>
   <name>Apache HttpAsyncClient</name>

--- a/httpasyncclient/pom.xml
+++ b/httpasyncclient/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.2-alpha1-SNAPSHOT</version>
+    <version>4.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient</artifactId>
   <name>Apache HttpAsyncClient</name>

--- a/httpasyncclient/pom.xml
+++ b/httpasyncclient/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-asyncclient</artifactId>
-    <version>4.1.3-SNAPSHOT</version>
+    <version>4.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>httpasyncclient</artifactId>
   <name>Apache HttpAsyncClient</name>

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientAuthentication.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientAuthentication.java
@@ -26,6 +26,8 @@
  */
 package org.apache.http.examples.nio.client;
 
+import java.util.concurrent.Future;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -34,8 +36,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
-
-import java.util.concurrent.Future;
 
 /**
  * A simple example that uses HttpClient to execute an HTTP request against
@@ -46,13 +46,14 @@ public class AsyncClientAuthentication {
     public static void main(String[] args) throws Exception {
         CredentialsProvider credsProvider = new BasicCredentialsProvider();
         credsProvider.setCredentials(
-                new AuthScope("localhost", 443),
-                new UsernamePasswordCredentials("username", "password"));
+                new AuthScope("httpbin.org", 80),
+                new UsernamePasswordCredentials("user", "passwd"));
         CloseableHttpAsyncClient httpclient = HttpAsyncClients.custom()
                 .setDefaultCredentialsProvider(credsProvider)
                 .build();
         try {
-            HttpGet httpget = new HttpGet("http://localhost/");
+            httpclient.start();
+            HttpGet httpget = new HttpGet("http://httpbin.org/basic-auth/user/passwd");
 
             System.out.println("Executing request " + httpget.getRequestLine());
             Future<HttpResponse> future = httpclient.execute(httpget, null);

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientConfiguration.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientConfiguration.java
@@ -42,6 +42,8 @@ import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.ParseException;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.AuthSchemes;
@@ -201,6 +203,7 @@ public class AsyncClientConfiguration {
         CookieStore cookieStore = new BasicCookieStore();
         // Use custom credentials provider if necessary.
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(new AuthScope("localhost", 8889), new UsernamePasswordCredentials("squid", "nopassword"));
         // Create global request configuration
         RequestConfig defaultRequestConfig = RequestConfig.custom()
             .setCookieSpec(CookieSpecs.DEFAULT)
@@ -214,19 +217,19 @@ public class AsyncClientConfiguration {
             .setConnectionManager(connManager)
             .setDefaultCookieStore(cookieStore)
             .setDefaultCredentialsProvider(credentialsProvider)
-            .setProxy(new HttpHost("myproxy", 8080))
+            .setProxy(new HttpHost("localhost", 8889))
             .setDefaultRequestConfig(defaultRequestConfig)
             .build();
 
         try {
-            HttpGet httpget = new HttpGet("http://localhost/");
+            HttpGet httpget = new HttpGet("http://httpbin.org/get");
             // Request configuration can be overridden at the request level.
             // They will take precedence over the one set at the client level.
             RequestConfig requestConfig = RequestConfig.copy(defaultRequestConfig)
                 .setSocketTimeout(5000)
                 .setConnectTimeout(5000)
                 .setConnectionRequestTimeout(5000)
-                .setProxy(new HttpHost("myotherproxy", 8080))
+                .setProxy(new HttpHost("localhost", 8888))
                 .build();
             httpget.setConfig(requestConfig);
 

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientCustomContext.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientCustomContext.java
@@ -27,17 +27,18 @@
 
 package org.apache.http.examples.nio.client;
 
+import java.util.List;
+import java.util.concurrent.Future;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.cookie.BasicClientCookie;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
-
-import java.util.List;
-import java.util.concurrent.Future;
 
 /**
  * This example demonstrates the use of a local HTTP context populated with
@@ -48,6 +49,8 @@ public class AsyncClientCustomContext {
     public final static void main(String[] args) throws Exception {
         CloseableHttpAsyncClient httpclient = HttpAsyncClients.createDefault();
         try {
+            httpclient.start();
+
             // Create a local instance of cookie store
             CookieStore cookieStore = new BasicCookieStore();
 
@@ -56,10 +59,13 @@ public class AsyncClientCustomContext {
             // Bind custom cookie store to the local context
             localContext.setCookieStore(cookieStore);
 
-            HttpGet httpget = new HttpGet("http://localhost/");
-            System.out.println("Executing request " + httpget.getRequestLine());
+            BasicClientCookie cookie = new BasicClientCookie("stuff", "important");
+            cookie.setDomain("httpbin.org");
+            cookie.setPath("/");
+            cookieStore.addCookie(cookie);
 
-            httpclient.start();
+            HttpGet httpget = new HttpGet("http://httpbin.org/cookies");
+            System.out.println("Executing request " + httpget.getRequestLine());
 
             // Pass local context as a parameter
             Future<HttpResponse> future = httpclient.execute(httpget, localContext, null);

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientCustomSSL.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientCustomSSL.java
@@ -26,9 +26,6 @@
  */
 package org.apache.http.examples.nio.client;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.security.KeyStore;
 import java.util.concurrent.Future;
 
 import javax.net.ssl.SSLContext;
@@ -48,16 +45,9 @@ import org.apache.http.ssl.SSLContexts;
 public class AsyncClientCustomSSL {
 
     public final static void main(String[] args) throws Exception {
-        KeyStore trustStore  = KeyStore.getInstance(KeyStore.getDefaultType());
-        FileInputStream instream = new FileInputStream(new File("my.keystore"));
-        try {
-            trustStore.load(instream, "nopassword".toCharArray());
-        } finally {
-            instream.close();
-        }
-        // Trust own CA and all self-signed certs
+        // Trust standard CAs and all self-signed certs
         SSLContext sslcontext = SSLContexts.custom()
-                .loadTrustMaterial(trustStore, new TrustSelfSignedStrategy())
+                .loadTrustMaterial(new TrustSelfSignedStrategy())
                 .build();
         // Allow TLSv1 protocol only
         SSLIOSessionStrategy sslSessionStrategy = new SSLIOSessionStrategy(
@@ -70,8 +60,8 @@ public class AsyncClientCustomSSL {
                 .build();
         try {
             httpclient.start();
-            HttpGet request = new HttpGet("https://issues.apache.org/");
-            Future<HttpResponse> future = httpclient.execute(request, null);
+            HttpGet httpget = new HttpGet("https://httpbin.org/");
+            Future<HttpResponse> future = httpclient.execute(httpget, null);
             HttpResponse response = future.get();
             System.out.println("Response: " + response.getStatusLine());
             System.out.println("Shutting down");

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientExecuteProxy.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientExecuteProxy.java
@@ -46,11 +46,11 @@ public class AsyncClientExecuteProxy {
         CloseableHttpAsyncClient httpclient = HttpAsyncClients.createDefault();
         try {
             httpclient.start();
-            HttpHost proxy = new HttpHost("someproxy", 8080);
+            HttpHost proxy = new HttpHost("localhost", 8888);
             RequestConfig config = RequestConfig.custom()
                     .setProxy(proxy)
                     .build();
-            HttpGet request = new HttpGet("https://issues.apache.org/");
+            HttpGet request = new HttpGet("https://httpbin.org/");
             request.setConfig(config);
             Future<HttpResponse> future = httpclient.execute(request, null);
             HttpResponse response = future.get();

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientHttpExchange.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientHttpExchange.java
@@ -43,7 +43,7 @@ public class AsyncClientHttpExchange {
         CloseableHttpAsyncClient httpclient = HttpAsyncClients.createDefault();
         try {
             httpclient.start();
-            HttpGet request = new HttpGet("http://www.apache.org/");
+            HttpGet request = new HttpGet("http://httpbin.org/get");
             Future<HttpResponse> future = httpclient.execute(request, null);
             HttpResponse response = future.get();
             System.out.println("Response: " + response.getStatusLine());

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientHttpExchangeFutureCallback.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientHttpExchangeFutureCallback.java
@@ -51,9 +51,9 @@ public class AsyncClientHttpExchangeFutureCallback {
         try {
             httpclient.start();
             final HttpGet[] requests = new HttpGet[] {
-                    new HttpGet("http://www.apache.org/"),
-                    new HttpGet("https://www.verisign.com/"),
-                    new HttpGet("http://www.google.com/")
+                    new HttpGet("http://httpbin.org/ip"),
+                    new HttpGet("https://httpbin.org/ip"),
+                    new HttpGet("http://httpbin.org/headers")
             };
             final CountDownLatch latch = new CountDownLatch(requests.length);
             for (final HttpGet request: requests) {

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientHttpExchangeStreaming.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientHttpExchangeStreaming.java
@@ -49,7 +49,7 @@ public class AsyncClientHttpExchangeStreaming {
         try {
             httpclient.start();
             Future<Boolean> future = httpclient.execute(
-                    HttpAsyncMethods.createGet("http://localhost:8080/"),
+                    HttpAsyncMethods.createGet("http://httpbin.org/"),
                     new MyResponseConsumer(), null);
             Boolean result = future.get();
             if (result != null && result.booleanValue()) {

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientPipelined.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientPipelined.java
@@ -48,19 +48,20 @@ public class AsyncClientPipelined {
         try {
             httpclient.start();
 
-            HttpHost targetHost = new HttpHost("localhost", 8080);
+            HttpHost targetHost = new HttpHost("httpbin.org", 80);
             HttpGet[] resquests = {
-                    new HttpGet("/docs/index.html"),
-                    new HttpGet("/docs/introduction.html"),
-                    new HttpGet("/docs/setup.html"),
-                    new HttpGet("/docs/config/index.html")
+                    new HttpGet("/"),
+                    new HttpGet("/ip"),
+                    new HttpGet("/headers"),
+                    new HttpGet("/get")
             };
 
             Future<List<HttpResponse>> future = httpclient.execute(targetHost,
                     Arrays.<HttpRequest>asList(resquests), null);
             List<HttpResponse> responses = future.get();
-            System.out.println(responses);
-
+            for (HttpResponse response: responses) {
+                System.out.println(response.getStatusLine());
+            }
             System.out.println("Shutting down");
         } finally {
             httpclient.close();

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientPipelinedStreaming.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientPipelinedStreaming.java
@@ -54,12 +54,12 @@ public class AsyncClientPipelinedStreaming {
         try {
             httpclient.start();
 
-            HttpHost targetHost = new HttpHost("localhost", 8080);
+            HttpHost targetHost = new HttpHost("httpbin.org", 80);
             HttpGet[] resquests = {
-                    new HttpGet("/docs/index.html"),
-                    new HttpGet("/docs/introduction.html"),
-                    new HttpGet("/docs/setup.html"),
-                    new HttpGet("/docs/config/index.html")
+                    new HttpGet("/"),
+                    new HttpGet("/ip"),
+                    new HttpGet("/headers"),
+                    new HttpGet("/get")
             };
 
             List<MyRequestProducer> requestProducers = new ArrayList<MyRequestProducer>();

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientProxyAuthentication.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/AsyncClientProxyAuthentication.java
@@ -49,18 +49,18 @@ public class AsyncClientProxyAuthentication {
     public static void main(String[] args)throws Exception {
         CredentialsProvider credsProvider = new BasicCredentialsProvider();
         credsProvider.setCredentials(
-                new AuthScope("someproxy", 8080),
-                new UsernamePasswordCredentials("username", "password"));
+                new AuthScope("localhost", 8889),
+                new UsernamePasswordCredentials("squid", "nopassword"));
         CloseableHttpAsyncClient httpclient = HttpAsyncClients.custom()
                 .setDefaultCredentialsProvider(credsProvider)
                 .build();
         try {
             httpclient.start();
-            HttpHost proxy = new HttpHost("someproxy", 8080);
+            HttpHost proxy = new HttpHost("localhost", 8889);
             RequestConfig config = RequestConfig.custom()
                     .setProxy(proxy)
                     .build();
-            HttpGet httpget = new HttpGet("https://issues.apache.org/");
+            HttpGet httpget = new HttpGet("https://httpbin.org/");
             httpget.setConfig(config);
             Future<HttpResponse> future = httpclient.execute(httpget, null);
             HttpResponse response = future.get();

--- a/httpasyncclient/src/examples/org/apache/http/examples/nio/client/QuickStart.java
+++ b/httpasyncclient/src/examples/org/apache/http/examples/nio/client/QuickStart.java
@@ -117,19 +117,19 @@ public class QuickStart {
                 @Override
                 public void completed(final HttpResponse response3) {
                     latch2.countDown();
-                    System.out.println(request2.getRequestLine() + "->" + response3.getStatusLine());
+                    System.out.println(request3.getRequestLine() + "->" + response3.getStatusLine());
                 }
 
                 @Override
                 public void failed(final Exception ex) {
                     latch2.countDown();
-                    System.out.println(request2.getRequestLine() + "->" + ex);
+                    System.out.println(request3.getRequestLine() + "->" + ex);
                 }
 
                 @Override
                 public void cancelled() {
                     latch2.countDown();
-                    System.out.println(request2.getRequestLine() + " cancelled");
+                    System.out.println(request3.getRequestLine() + " cancelled");
                 }
 
             });

--- a/httpasyncclient/src/main/java-deprecated/org/apache/http/impl/nio/client/AbstractHttpAsyncClient.java
+++ b/httpasyncclient/src/main/java-deprecated/org/apache/http/impl/nio/client/AbstractHttpAsyncClient.java
@@ -513,10 +513,10 @@ public abstract class AbstractHttpAsyncClient implements HttpAsyncClient {
         }
         final BasicFuture<T> future = new BasicFuture<T>(callback);
         final ResultCallback<T> resultCallback = new DefaultResultCallback<T>(future, this.queue);
-        DefaultAsyncRequestDirector<T> httpexchange;
+        final DefaultAsyncRequestDirector<T> httpexchange;
         synchronized (this) {
             final HttpContext defaultContext = createHttpContext();
-            HttpContext execContext;
+            final HttpContext execContext;
             if (context == null) {
                 execContext = defaultContext;
             } else {
@@ -581,7 +581,7 @@ public abstract class AbstractHttpAsyncClient implements HttpAsyncClient {
             final HttpUriRequest request,
             final HttpContext context,
             final FutureCallback<HttpResponse> callback) {
-        HttpHost target;
+        final HttpHost target;
         try {
             target = determineTarget(request);
         } catch (final ClientProtocolException ex) {

--- a/httpasyncclient/src/main/java-deprecated/org/apache/http/impl/nio/conn/AsyncSchemeRegistryFactory.java
+++ b/httpasyncclient/src/main/java-deprecated/org/apache/http/impl/nio/conn/AsyncSchemeRegistryFactory.java
@@ -26,13 +26,15 @@
  */
 package org.apache.http.impl.nio.conn;
 
-import org.apache.http.annotation.ThreadSafe;
+
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.nio.conn.scheme.AsyncScheme;
 import org.apache.http.nio.conn.scheme.AsyncSchemeRegistry;
 import org.apache.http.nio.conn.ssl.SSLLayeringStrategy;
 
 @Deprecated
-@ThreadSafe
+@Contract(threading = ThreadingBehavior.SAFE)
 public final class AsyncSchemeRegistryFactory {
 
     public static AsyncSchemeRegistry createDefault() {

--- a/httpasyncclient/src/main/java-deprecated/org/apache/http/impl/nio/conn/DefaultHttpAsyncRoutePlanner.java
+++ b/httpasyncclient/src/main/java-deprecated/org/apache/http/impl/nio/conn/DefaultHttpAsyncRoutePlanner.java
@@ -77,7 +77,7 @@ public class DefaultHttpAsyncRoutePlanner implements HttpRoutePlanner {
         }
         final InetAddress local = ConnRouteParams.getLocalAddress(request.getParams());
         final HttpHost proxy = ConnRouteParams.getDefaultProxy(request.getParams());
-        AsyncScheme scheme;
+        final AsyncScheme scheme;
         try {
             final AsyncSchemeRegistry registry = getSchemeRegistry(context);
             scheme = registry.getScheme(target);

--- a/httpasyncclient/src/main/java-deprecated/org/apache/http/impl/nio/conn/PoolingClientAsyncConnectionManager.java
+++ b/httpasyncclient/src/main/java-deprecated/org/apache/http/impl/nio/conn/PoolingClientAsyncConnectionManager.java
@@ -213,7 +213,7 @@ public class PoolingClientAsyncConnectionManager
                 if (managedConn.isOpen()) {
                     entry.updateExpiry(keepalive, tunit != null ? tunit : TimeUnit.MILLISECONDS);
                     if (this.log.isDebugEnabled()) {
-                        String s;
+                        final String s;
                         if (keepalive > 0) {
                             s = "for " + keepalive + " " + tunit;
                         } else {

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/AbstractClientExchangeHandler.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/AbstractClientExchangeHandler.java
@@ -162,11 +162,15 @@ abstract class AbstractClientExchangeHandler implements HttpAsyncClientExchangeH
             final boolean routeComplete = this.connmgr.isRouteComplete(managedConn);
             this.routeEstablished.set(routeComplete);
             if (!routeComplete) {
-                this.log.debug("Start connection routing");
+                if (this.log.isDebugEnabled()) {
+                    this.log.debug("[exchange: " + this.id + "] Start connection routing");
+                }
                 final HttpRoute route = this.routeRef.get();
                 this.routeTrackerRef.set(new RouteTracker(route));
             } else {
-                this.log.debug("Connection route already established");
+                if (this.log.isDebugEnabled()) {
+                    this.log.debug("[exchange: " + this.id + "] Connection route already established");
+                }
             }
         }
     }
@@ -216,6 +220,9 @@ abstract class AbstractClientExchangeHandler implements HttpAsyncClientExchangeH
         Asserts.check(managedConn != null, "Inconsistent state: managed connection is null");
         final HttpRoute route = this.routeRef.get();
         Asserts.check(route != null, "Inconsistent state: HTTP route is null");
+        if (this.log.isDebugEnabled()) {
+            this.log.debug("[exchange: " + this.id + "] route completed");
+        }
         this.connmgr.routeComplete(managedConn, route, this.localContext);
         this.routeEstablished.set(true);
         this.routeTrackerRef.set(null);
@@ -244,7 +251,7 @@ abstract class AbstractClientExchangeHandler implements HttpAsyncClientExchangeH
                     }
                 } catch (final IOException ex) {
                     if (this.log.isDebugEnabled()) {
-                        this.log.debug(ex.getMessage(), ex);
+                        this.log.debug("[exchange: " + this.id + "] " + ex.getMessage(), ex);
                     }
                 } finally {
                     this.connmgr.releaseConnection(localConn, null, 0, TimeUnit.MILLISECONDS);
@@ -263,7 +270,7 @@ abstract class AbstractClientExchangeHandler implements HttpAsyncClientExchangeH
                 }
             } catch (final IOException ex) {
                 if (this.log.isDebugEnabled()) {
-                    this.log.debug(ex.getMessage(), ex);
+                    this.log.debug("[exchange: " + this.id + "] " + ex.getMessage(), ex);
                 }
             } finally {
                 this.connmgr.releaseConnection(localConn, null, 0, TimeUnit.MILLISECONDS);

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/AbstractClientExchangeHandler.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/AbstractClientExchangeHandler.java
@@ -320,6 +320,11 @@ abstract class AbstractClientExchangeHandler implements HttpAsyncClientExchangeH
                 return;
             }
 
+            if (this.connmgr.isRouteComplete(managedConn)) {
+                this.routeEstablished.set(true);
+                this.routeTrackerRef.set(null);
+            }
+
             final HttpContext context = managedConn.getContext();
             synchronized (context) {
                 context.setAttribute(HttpAsyncRequestExecutor.HTTP_HANDLER, this);

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/CloseableHttpAsyncClient.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/CloseableHttpAsyncClient.java
@@ -33,7 +33,8 @@ import java.util.concurrent.Future;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
-import org.apache.http.annotation.ThreadSafe;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
@@ -52,7 +53,7 @@ import org.apache.http.util.Args;
  *
  * @since 4.0
  */
-@ThreadSafe
+@Contract(threading = ThreadingBehavior.SAFE)
 public abstract class CloseableHttpAsyncClient implements HttpAsyncClient, Closeable {
 
     public abstract boolean isRunning();

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/CloseableHttpAsyncClientBase.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/CloseableHttpAsyncClientBase.java
@@ -97,7 +97,7 @@ abstract class CloseableHttpAsyncClientBase extends CloseableHttpPipeliningClien
             if (this.reactorThread != null) {
                 try {
                     this.connmgr.shutdown();
-                } catch (IOException ex) {
+                } catch (final IOException ex) {
                     this.log.error("I/O error shutting down connection manager", ex);
                 }
                 try {

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/CloseableHttpPipeliningClient.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/CloseableHttpPipeliningClient.java
@@ -33,7 +33,8 @@ import java.util.concurrent.Future;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
-import org.apache.http.annotation.ThreadSafe;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.nio.client.HttpPipeliningClient;
@@ -49,7 +50,7 @@ import org.apache.http.util.Args;
  *
  * @since 4.1
  */
-@ThreadSafe
+@Contract(threading = ThreadingBehavior.SAFE)
 public abstract class CloseableHttpPipeliningClient
         extends CloseableHttpAsyncClient implements HttpPipeliningClient {
 

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/DefaultAsyncUserTokenHandler.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/DefaultAsyncUserTokenHandler.java
@@ -27,7 +27,8 @@
 package org.apache.http.impl.nio.client;
 
 import org.apache.http.HttpConnection;
-import org.apache.http.annotation.Immutable;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.auth.AuthScheme;
 import org.apache.http.auth.AuthState;
 import org.apache.http.auth.Credentials;
@@ -55,7 +56,7 @@ import java.security.Principal;
  *
  * @since 4.0
  */
-@Immutable
+@Contract(threading = ThreadingBehavior.IMMUTABLE)
 public class DefaultAsyncUserTokenHandler implements UserTokenHandler {
 
     public static final DefaultAsyncUserTokenHandler INSTANCE = new DefaultAsyncUserTokenHandler();

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/DefaultClientExchangeHandlerImpl.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/DefaultClientExchangeHandlerImpl.java
@@ -70,7 +70,7 @@ class DefaultClientExchangeHandlerImpl<T> extends AbstractClientExchangeHandler 
             final ConnectionReuseStrategy connReuseStrategy,
             final ConnectionKeepAliveStrategy keepaliveStrategy,
             final InternalClientExec exec) {
-        super(log, localContext, resultFuture, connmgr, connReuseStrategy, keepaliveStrategy);
+        super(log, localContext, connmgr, connReuseStrategy, keepaliveStrategy);
         this.requestProducer = requestProducer;
         this.responseConsumer = responseConsumer;
         this.resultFuture = resultFuture;
@@ -94,8 +94,12 @@ class DefaultClientExchangeHandlerImpl<T> extends AbstractClientExchangeHandler 
 
     @Override
     void executionFailed(final Exception ex) {
-        this.requestProducer.failed(ex);
-        this.responseConsumer.failed(ex);
+        try {
+            this.requestProducer.failed(ex);
+            this.responseConsumer.failed(ex);
+        } finally {
+            this.resultFuture.failed(ex);
+        }
     }
 
     @Override

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/FutureWrapper.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/FutureWrapper.java
@@ -1,0 +1,83 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.impl.nio.client;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.http.concurrent.Cancellable;
+
+final class FutureWrapper<T> implements Future<T> {
+
+    private final Future<T> future;
+    private final Cancellable cancellable;
+
+    public FutureWrapper(final Future<T> future, final Cancellable cancellable) {
+        super();
+        this.future = future;
+        this.cancellable = cancellable;
+    }
+
+    @Override
+    public boolean cancel(final boolean mayInterruptIfRunning) {
+        try {
+            if (cancellable != null) {
+                cancellable.cancel();
+            }
+        } finally {
+            return future.cancel(mayInterruptIfRunning);
+        }
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return future.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return future.isDone();
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        return future.get();
+    }
+
+    @Override
+    public T get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return future.get(timeout, unit);
+    }
+
+    @Override
+    public String toString() {
+        return future.toString();
+    }
+
+}

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.java
@@ -666,7 +666,7 @@ public class HttpAsyncClientBuilder {
                         sslcontext, supportedProtocols, supportedCipherSuites, hostnameVerifier);
             }
             final ConnectingIOReactor ioreactor = IOReactorUtils.create(
-                defaultIOReactorConfig != null ? defaultIOReactorConfig : IOReactorConfig.DEFAULT);
+                defaultIOReactorConfig != null ? defaultIOReactorConfig : IOReactorConfig.DEFAULT, threadFactory);
             final PoolingNHttpClientConnectionManager poolingmgr = new PoolingNHttpClientConnectionManager(
                     ioreactor,
                     RegistryBuilder.<SchemeIOSessionStrategy>create()

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.java
@@ -41,7 +41,6 @@ import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponseInterceptor;
-import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.auth.AuthSchemeProvider;
 import org.apache.http.client.AuthenticationStrategy;
 import org.apache.http.client.CookieStore;
@@ -142,7 +141,6 @@ import org.apache.http.util.VersionInfo;
  *
  * @since 4.0
  */
-@NotThreadSafe
 public class HttpAsyncClientBuilder {
 
     private NHttpClientConnectionManager connManager;

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.java
@@ -649,9 +649,9 @@ public class HttpAsyncClientBuilder {
                 SSLContext sslcontext = this.sslcontext;
                 if (sslcontext == null) {
                     if (systemProperties) {
-                        sslcontext = SSLContexts.createDefault();
-                    } else {
                         sslcontext = SSLContexts.createSystemDefault();
+                    } else {
+                        sslcontext = SSLContexts.createDefault();
                     }
                 }
                 final String[] supportedProtocols = systemProperties ? split(

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.java
@@ -80,6 +80,7 @@ import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.NoopUserTokenHandler;
 import org.apache.http.impl.client.ProxyAuthenticationStrategy;
+import org.apache.http.impl.client.SystemDefaultCredentialsProvider;
 import org.apache.http.impl.client.TargetAuthenticationStrategy;
 import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.apache.http.impl.conn.DefaultRoutePlanner;
@@ -831,9 +832,12 @@ public class HttpAsyncClientBuilder {
 
         CredentialsProvider defaultCredentialsProvider = this.credentialsProvider;
         if (defaultCredentialsProvider == null) {
-            defaultCredentialsProvider = new BasicCredentialsProvider();
+            if (systemProperties) {
+                defaultCredentialsProvider = new SystemDefaultCredentialsProvider();
+            } else {
+                defaultCredentialsProvider = new BasicCredentialsProvider();
+            }
         }
-
         RedirectStrategy redirectStrategy = this.redirectStrategy;
         if (redirectStrategy == null) {
             redirectStrategy = DefaultRedirectStrategy.INSTANCE;

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/HttpAsyncClients.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/HttpAsyncClients.java
@@ -27,7 +27,6 @@
 
 package org.apache.http.impl.nio.client;
 
-import org.apache.http.annotation.Immutable;
 import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
 import org.apache.http.nio.conn.NHttpClientConnectionManager;
 import org.apache.http.nio.reactor.ConnectingIOReactor;
@@ -39,7 +38,6 @@ import org.apache.http.util.Args;
  *
  * @since 4.0
  */
-@Immutable
 public class HttpAsyncClients {
 
     private HttpAsyncClients() {

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/IOReactorUtils.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/IOReactorUtils.java
@@ -26,6 +26,8 @@
  */
 package org.apache.http.impl.nio.client;
 
+import java.util.concurrent.ThreadFactory;
+
 import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.apache.http.nio.reactor.ConnectingIOReactor;
@@ -36,9 +38,9 @@ final class IOReactorUtils {
     private IOReactorUtils() {
     }
 
-    public static ConnectingIOReactor create(final IOReactorConfig config) {
+    public static ConnectingIOReactor create(final IOReactorConfig config, final ThreadFactory threadFactory) {
         try {
-            return new DefaultConnectingIOReactor(config);
+            return new DefaultConnectingIOReactor(config, threadFactory);
         } catch (final IOReactorException ex) {
             throw new IllegalStateException(ex);
         }

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/InternalClientExec.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/InternalClientExec.java
@@ -42,11 +42,11 @@ interface InternalClientExec {
             HttpHost target,
             HttpRequest original,
             InternalState state,
-            AbstractClientExchangeHandler<?> handler) throws IOException, HttpException;
+            AbstractClientExchangeHandler handler) throws IOException, HttpException;
 
     HttpRequest generateRequest(
             InternalState state,
-            AbstractClientExchangeHandler<?> handler) throws IOException, HttpException;
+            AbstractClientExchangeHandler handler) throws IOException, HttpException;
 
     void produceContent(
             InternalState state,
@@ -55,12 +55,12 @@ interface InternalClientExec {
 
     void requestCompleted(
             InternalState state,
-            AbstractClientExchangeHandler<?> handler);
+            AbstractClientExchangeHandler handler);
 
     void responseReceived(
             HttpResponse response,
             InternalState state,
-            AbstractClientExchangeHandler<?> handler) throws IOException, HttpException;
+            AbstractClientExchangeHandler handler) throws IOException, HttpException;
 
     void consumeContent(
             InternalState state,
@@ -69,6 +69,6 @@ interface InternalClientExec {
 
     void responseCompleted(
             InternalState state,
-            AbstractClientExchangeHandler<?> handler) throws IOException, HttpException;
+            AbstractClientExchangeHandler handler) throws IOException, HttpException;
 
 }

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/InternalHttpAsyncClient.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/InternalHttpAsyncClient.java
@@ -142,7 +142,7 @@ class InternalHttpAsyncClient extends CloseableHttpAsyncClientBase {
         } catch (final Exception ex) {
             handler.failed(ex);
         }
-        return future;
+        return new FutureWrapper<T>(future, handler);
     }
 
     @Override

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MainClientExec.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MainClientExec.java
@@ -185,7 +185,7 @@ class MainClientExec implements InternalClientExec {
                             "planned = " + route + "; current = " + fact);
                 case HttpRouteDirector.COMPLETE:
                     handler.onRouteComplete();
-                    this.log.debug("Connection route established");
+                    this.log.debug("[exchange: " + state.getId() + "] Connection route established");
                     break;
                 default:
                     throw new IllegalStateException("Unknown step indicator "
@@ -219,14 +219,14 @@ class MainClientExec implements InternalClientExec {
             if (!currentRequest.containsHeader(AUTH.WWW_AUTH_RESP)) {
                 final AuthState targetAuthState = localContext.getTargetAuthState();
                 if (this.log.isDebugEnabled()) {
-                    this.log.debug("Target auth state: " + targetAuthState.getState());
+                    this.log.debug("[exchange: " + state.getId() + "] Target auth state: " + targetAuthState.getState());
                 }
                 this.authenticator.generateAuthResponse(currentRequest, targetAuthState, localContext);
             }
             if (!currentRequest.containsHeader(AUTH.PROXY_AUTH_RESP) && !route.isTunnelled()) {
                 final AuthState proxyAuthState = localContext.getProxyAuthState();
                 if (this.log.isDebugEnabled()) {
-                    this.log.debug("Proxy auth state: " + proxyAuthState.getState());
+                    this.log.debug("[exchange: " + state.getId() + "] Proxy auth state: " + proxyAuthState.getState());
                 }
                 this.authenticator.generateAuthResponse(currentRequest, proxyAuthState, localContext);
             }
@@ -234,7 +234,7 @@ class MainClientExec implements InternalClientExec {
             if (!currentRequest.containsHeader(AUTH.PROXY_AUTH_RESP)) {
                 final AuthState proxyAuthState = localContext.getProxyAuthState();
                 if (this.log.isDebugEnabled()) {
-                    this.log.debug("Proxy auth state: " + proxyAuthState.getState());
+                    this.log.debug("[exchange: " + state.getId() + "] Proxy auth state: " + proxyAuthState.getState());
                 }
                 this.authenticator.generateAuthResponse(currentRequest, proxyAuthState, localContext);
             }
@@ -484,8 +484,8 @@ class MainClientExec implements InternalClientExec {
                 uri = URI.create(uriString);
             } catch (final IllegalArgumentException ex) {
                 if (this.log.isDebugEnabled()) {
-                    this.log.debug("Unable to parse '" + uriString + "' as a valid URI; " +
-                        "request URI and Host header may be inconsistent", ex);
+                    this.log.debug("[exchange: " + state.getId() + "] Unable to parse '" + uriString +
+                            "' as a valid URI; request URI and Host header may be inconsistent", ex);
                 }
             }
 

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MainClientExec.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MainClientExec.java
@@ -116,7 +116,7 @@ class MainClientExec implements InternalClientExec {
             final HttpHost target,
             final HttpRequest original,
             final InternalState state,
-            final AbstractClientExchangeHandler<?> handler) throws HttpException, IOException {
+            final AbstractClientExchangeHandler handler) throws HttpException, IOException {
         if (this.log.isDebugEnabled()) {
             this.log.debug("[exchange: " + state.getId() + "] start execution");
         }
@@ -149,7 +149,7 @@ class MainClientExec implements InternalClientExec {
     @Override
     public HttpRequest generateRequest(
             final InternalState state,
-            final AbstractClientExchangeHandler<?> handler) throws IOException, HttpException {
+            final AbstractClientExchangeHandler handler) throws IOException, HttpException {
 
         final HttpRoute route = handler.getRoute();
 
@@ -268,7 +268,7 @@ class MainClientExec implements InternalClientExec {
     @Override
     public void requestCompleted(
             final InternalState state,
-            final AbstractClientExchangeHandler<?> handler) {
+            final AbstractClientExchangeHandler handler) {
         if (this.log.isDebugEnabled()) {
             this.log.debug("[exchange: " + state.getId() + "] Request completed");
         }
@@ -281,7 +281,7 @@ class MainClientExec implements InternalClientExec {
     public void responseReceived(
             final HttpResponse response,
             final InternalState state,
-            final AbstractClientExchangeHandler<?> handler) throws IOException, HttpException {
+            final AbstractClientExchangeHandler handler) throws IOException, HttpException {
         if (this.log.isDebugEnabled()) {
             this.log.debug("[exchange: " + state.getId() + "] Response received " + response.getStatusLine());
         }
@@ -337,7 +337,7 @@ class MainClientExec implements InternalClientExec {
     @Override
     public void responseCompleted(
             final InternalState state,
-            final AbstractClientExchangeHandler<?> handler) throws IOException, HttpException {
+            final AbstractClientExchangeHandler handler) throws IOException, HttpException {
         final HttpClientContext localContext = state.getLocalContext();
         final HttpResponse currentResponse = handler.getCurrentResponse();
 
@@ -469,7 +469,7 @@ class MainClientExec implements InternalClientExec {
 
     private void prepareRequest(
             final InternalState state,
-            final AbstractClientExchangeHandler<?> handler) throws IOException, HttpException {
+            final AbstractClientExchangeHandler handler) throws IOException, HttpException {
         final HttpClientContext localContext = state.getLocalContext();
         final HttpRequestWrapper currentRequest = handler.getCurrentRequest();
         final HttpRoute route = handler.getRoute();
@@ -540,7 +540,7 @@ class MainClientExec implements InternalClientExec {
 
     private boolean handleConnectResponse(
             final InternalState state,
-            final AbstractClientExchangeHandler<?> handler) throws HttpException {
+            final AbstractClientExchangeHandler handler) throws HttpException {
         final HttpClientContext localContext = state.getLocalContext();
         final RequestConfig config = localContext.getRequestConfig();
         if (config.isAuthenticationEnabled()) {
@@ -562,7 +562,7 @@ class MainClientExec implements InternalClientExec {
 
     private boolean handleResponse(
             final InternalState state,
-            final AbstractClientExchangeHandler<?> handler) throws HttpException {
+            final AbstractClientExchangeHandler handler) throws HttpException {
         final HttpClientContext localContext = state.getLocalContext();
         final RequestConfig config = localContext.getRequestConfig();
         if (config.isAuthenticationEnabled()) {
@@ -599,7 +599,7 @@ class MainClientExec implements InternalClientExec {
 
     private boolean needAuthentication(
             final InternalState state,
-            final AbstractClientExchangeHandler<?> handler) throws HttpException {
+            final AbstractClientExchangeHandler handler) throws HttpException {
         final HttpClientContext localContext = state.getLocalContext();
         final CredentialsProvider credsProvider = localContext.getCredentialsProvider();
         if (credsProvider != null) {

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MinimalClientExchangeHandlerImpl.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MinimalClientExchangeHandlerImpl.java
@@ -76,7 +76,7 @@ class MinimalClientExchangeHandlerImpl<T> extends AbstractClientExchangeHandler 
             final HttpProcessor httpProcessor,
             final ConnectionReuseStrategy connReuseStrategy,
             final ConnectionKeepAliveStrategy keepaliveStrategy) {
-        super(log, localContext, resultFuture, connmgr, connReuseStrategy, keepaliveStrategy);
+        super(log, localContext, connmgr, connReuseStrategy, keepaliveStrategy);
         this.requestProducer = requestProducer;
         this.responseConsumer = responseConsumer;
         this.localContext = localContext;

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MinimalHttpAsyncClient.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MinimalHttpAsyncClient.java
@@ -111,7 +111,7 @@ class MinimalHttpAsyncClient extends CloseableHttpAsyncClientBase {
         } catch (final Exception ex) {
             handler.failed(ex);
         }
-        return future;
+        return new FutureWrapper<T>(future, handler);
     }
 
     @Override
@@ -142,7 +142,7 @@ class MinimalHttpAsyncClient extends CloseableHttpAsyncClientBase {
         } catch (final Exception ex) {
             handler.failed(ex);
         }
-        return future;
+        return new FutureWrapper<List<T>>(future, handler);
     }
 
 }

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MinimalHttpAsyncClientBuilder.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MinimalHttpAsyncClientBuilder.java
@@ -117,8 +117,8 @@ class MinimalHttpAsyncClientBuilder {
 
         NHttpClientConnectionManager connManager = this.connManager;
         if (connManager == null) {
-            connManager = new PoolingNHttpClientConnectionManager(
-                    IOReactorUtils.create(IOReactorConfig.DEFAULT));
+            connManager = new PoolingNHttpClientConnectionManager(IOReactorUtils.create(IOReactorConfig.DEFAULT,
+                    threadFactory));
         }
         ConnectionReuseStrategy reuseStrategy = this.reuseStrategy;
         if (reuseStrategy == null) {

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MinimalHttpAsyncClientBuilder.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/MinimalHttpAsyncClientBuilder.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
 import org.apache.http.ConnectionReuseStrategy;
-import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.client.protocol.RequestAddCookies;
 import org.apache.http.client.protocol.RequestClientConnControl;
 import org.apache.http.client.protocol.ResponseProcessCookies;
@@ -55,7 +54,6 @@ import org.apache.http.util.VersionInfo;
  *
  * @since 4.1
  */
-@NotThreadSafe
 class MinimalHttpAsyncClientBuilder {
 
     private NHttpClientConnectionManager connManager;

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/PipeliningClientExchangeHandlerImpl.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/PipeliningClientExchangeHandlerImpl.java
@@ -113,7 +113,7 @@ class PipeliningClientExchangeHandlerImpl<T> extends AbstractClientExchangeHandl
         if (requestProducer != null) {
             try {
                 requestProducer.close();
-            } catch (IOException ex) {
+            } catch (final IOException ex) {
                 this.log.debug("I/O error closing request producer", ex);
             }
         }
@@ -123,7 +123,7 @@ class PipeliningClientExchangeHandlerImpl<T> extends AbstractClientExchangeHandl
         if (responseConsumer != null) {
             try {
                 responseConsumer.close();
-            } catch (IOException ex) {
+            } catch (final IOException ex) {
                 this.log.debug("I/O error closing response consumer", ex);
             }
         }
@@ -236,7 +236,7 @@ class PipeliningClientExchangeHandlerImpl<T> extends AbstractClientExchangeHandl
         requestProducer.requestCompleted(this.localContext);
         try {
             requestProducer.close();
-        } catch (IOException ioex) {
+        } catch (final IOException ioex) {
             this.log.debug(ioex.getMessage(), ioex);
         }
     }
@@ -293,7 +293,7 @@ class PipeliningClientExchangeHandlerImpl<T> extends AbstractClientExchangeHandl
             final Exception ex = responseConsumer.getException();
             try {
                 responseConsumer.close();
-            } catch (IOException ioex) {
+            } catch (final IOException ioex) {
                 this.log.debug(ioex.getMessage(), ioex);
             }
             if (result != null) {

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/PipeliningClientExchangeHandlerImpl.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/PipeliningClientExchangeHandlerImpl.java
@@ -91,7 +91,7 @@ class PipeliningClientExchangeHandlerImpl<T> extends AbstractClientExchangeHandl
             final HttpProcessor httpProcessor,
             final ConnectionReuseStrategy connReuseStrategy,
             final ConnectionKeepAliveStrategy keepaliveStrategy) {
-        super(log, localContext, resultFuture, connmgr, connReuseStrategy, keepaliveStrategy);
+        super(log, localContext, connmgr, connReuseStrategy, keepaliveStrategy);
         Args.notNull(target, "HTTP target");
         Args.notEmpty(requestProducers, "Request producer list");
         Args.notEmpty(responseConsumers, "Response consumer list");

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/CPool.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/CPool.java
@@ -30,7 +30,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.annotation.ThreadSafe;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.conn.routing.HttpRoute;
 import org.apache.http.nio.NHttpClientConnection;
 import org.apache.http.nio.conn.ManagedNHttpClientConnection;
@@ -39,7 +40,7 @@ import org.apache.http.nio.pool.NIOConnFactory;
 import org.apache.http.nio.pool.SocketAddressResolver;
 import org.apache.http.nio.reactor.ConnectingIOReactor;
 
-@ThreadSafe
+@Contract(threading = ThreadingBehavior.SAFE)
 class CPool extends AbstractNIOConnPool<HttpRoute, ManagedNHttpClientConnection, CPoolEntry> {
 
     private final Log log = LogFactory.getLog(CPool.class);

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/CPool.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/CPool.java
@@ -74,7 +74,6 @@ class CPool extends AbstractNIOConnPool<HttpRoute, ManagedNHttpClientConnection,
     @Override
     protected void onRelease(final CPoolEntry entry) {
         final NHttpClientConnection conn = entry.getConnection();
-        entry.setSocketTimeout(conn.getSocketTimeout());
         conn.setSocketTimeout(0);
     }
 

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/CPoolEntry.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/CPoolEntry.java
@@ -31,12 +31,13 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
-import org.apache.http.annotation.ThreadSafe;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.conn.routing.HttpRoute;
 import org.apache.http.nio.conn.ManagedNHttpClientConnection;
 import org.apache.http.pool.PoolEntry;
 
-@ThreadSafe
+@Contract(threading = ThreadingBehavior.SAFE)
 class CPoolEntry extends PoolEntry<HttpRoute, ManagedNHttpClientConnection> {
 
     private final Log log;

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/CPoolProxy.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/CPoolProxy.java
@@ -35,14 +35,12 @@ import org.apache.http.HttpConnectionMetrics;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
-import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.impl.conn.ConnectionShutdownException;
 import org.apache.http.nio.NHttpClientConnection;
 import org.apache.http.nio.conn.ManagedNHttpClientConnection;
 import org.apache.http.nio.reactor.IOSession;
 import org.apache.http.protocol.HttpContext;
 
-@NotThreadSafe
 class CPoolProxy implements ManagedNHttpClientConnection {
 
     private volatile CPoolEntry poolEntry;

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/PoolingNHttpClientConnectionManager.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/PoolingNHttpClientConnectionManager.java
@@ -39,7 +39,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHost;
-import org.apache.http.annotation.ThreadSafe;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.concurrent.BasicFuture;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.config.ConnectionConfig;
@@ -88,7 +89,7 @@ import org.apache.http.util.Asserts;
  *
  * @since 4.0
  */
-@ThreadSafe
+@Contract(threading = ThreadingBehavior.SAFE)
 public class PoolingNHttpClientConnectionManager
        implements NHttpClientConnectionManager, ConnPoolControl<HttpRoute> {
 

--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/PoolingNHttpClientConnectionManager.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/conn/PoolingNHttpClientConnectionManager.java
@@ -472,6 +472,11 @@ public class PoolingNHttpClientConnectionManager
         this.pool.closeExpired();
     }
 
+    public void validatePendingRequests() {
+        log.debug("Validating pending requests");
+        this.pool.validatePendingRequests();
+    }
+
     @Override
     public int getMaxTotal() {
         return this.pool.getMaxTotal();

--- a/httpasyncclient/src/main/java/org/apache/http/nio/client/methods/HttpAsyncMethods.java
+++ b/httpasyncclient/src/main/java/org/apache/http/nio/client/methods/HttpAsyncMethods.java
@@ -37,6 +37,7 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
@@ -112,7 +113,7 @@ public final class HttpAsyncMethods {
      * @return asynchronous request generator
      */
     public static HttpAsyncRequestProducer createHead(final URI requestURI) {
-        return create(new HttpGet(requestURI));
+        return create(new HttpHead(requestURI));
     }
 
     /**
@@ -122,7 +123,7 @@ public final class HttpAsyncMethods {
      * @return asynchronous request generator
      */
     public static HttpAsyncRequestProducer createHead(final String requestURI) {
-        return create(new HttpGet(URI.create(requestURI)));
+        return create(new HttpHead(URI.create(requestURI)));
     }
 
     /**

--- a/httpasyncclient/src/main/java/org/apache/http/nio/client/methods/HttpAsyncMethods.java
+++ b/httpasyncclient/src/main/java/org/apache/http/nio/client/methods/HttpAsyncMethods.java
@@ -233,6 +233,7 @@ public final class HttpAsyncMethods {
             final ContentType contentType) {
         final HttpPost httppost = new HttpPost(requestURI);
         final NByteArrayEntity entity = new NByteArrayEntity(content, contentType);
+        httppost.setEntity(entity);
         final HttpHost target = URIUtils.extractHost(requestURI);
         return new RequestProducerImpl(target, httppost, entity);
     }
@@ -300,6 +301,7 @@ public final class HttpAsyncMethods {
             final ContentType contentType) {
         final HttpPut httpput = new HttpPut(requestURI);
         final NByteArrayEntity entity = new NByteArrayEntity(content, contentType);
+        httpput.setEntity(entity);
         final HttpHost target = URIUtils.extractHost(requestURI);
         return new RequestProducerImpl(target, httpput, entity);
     }

--- a/httpasyncclient/src/test/java/org/apache/http/impl/nio/conn/TestPoolingHttpClientAsyncConnectionManager.java
+++ b/httpasyncclient/src/test/java/org/apache/http/impl/nio/conn/TestPoolingHttpClientAsyncConnectionManager.java
@@ -29,6 +29,7 @@ package org.apache.http.impl.nio.conn;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Calendar;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -234,7 +235,7 @@ public class TestPoolingHttpClientAsyncConnectionManager {
         future.get();
     }
 
-    @Test
+    @Test(expected = CancellationException.class)
     public void testRequestConnectionCancelled() throws Exception {
         final HttpHost target = new HttpHost("localhost");
         final HttpRoute route = new HttpRoute(target);
@@ -254,7 +255,7 @@ public class TestPoolingHttpClientAsyncConnectionManager {
 
         Assert.assertTrue(future.isDone());
         Assert.assertTrue(future.isCancelled());
-        Assert.assertNull(future.get());
+        future.get();
     }
 
     @Test

--- a/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsync.java
+++ b/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsync.java
@@ -113,6 +113,26 @@ public class TestHttpAsync extends HttpAsyncTestBase {
     }
 
     @Test
+    public void testHttpAsyncMethods() throws Exception {
+        final HttpHost target = start();
+        final byte[] b1 = new byte[1024];
+        final Random rnd = new Random(System.currentTimeMillis());
+        rnd.nextBytes(b1);
+
+        final Future<HttpResponse> future = this.httpclient.execute(
+            HttpAsyncMethods.createPost(target + "/echo/post", b1, null),
+            new BasicAsyncResponseConsumer(),
+            null);
+        final HttpResponse response = future.get();
+        Assert.assertNotNull(response);
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        final HttpEntity entity = response.getEntity();
+        Assert.assertNotNull(entity);
+        final byte[] b2 = EntityUtils.toByteArray(entity);
+        Assert.assertArrayEquals(b1, b2);
+    }
+
+    @Test
     public void testMultiplePostsOverMultipleConnections() throws Exception {
         final HttpHost target = start();
         final byte[] b1 = new byte[1024];

--- a/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsync.java
+++ b/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsync.java
@@ -35,6 +35,7 @@ import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.apache.http.client.methods.HttpHead;
 import org.apache.http.localserver.HttpAsyncTestBase;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -90,6 +91,18 @@ public class TestHttpAsync extends HttpAsyncTestBase {
         final HttpResponse response = future.get();
         Assert.assertNotNull(response);
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void testMultipleHead() throws Exception {
+        final HttpHost target = start();
+        for (int i = 0; i < 3; i++) {
+            final HttpHead httpHead = new HttpHead("/random/2048");
+            final Future<HttpResponse> future = this.httpclient.execute(target, httpHead, null);
+            final HttpResponse response = future.get();
+            Assert.assertNotNull(response);
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        }
     }
 
     @Test

--- a/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPipelining.java
+++ b/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPipelining.java
@@ -26,16 +26,6 @@
  */
 package org.apache.http.nio.client.integration;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-
-import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -48,18 +38,21 @@ import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.http.localserver.AbstractAsyncTest;
 import org.apache.http.localserver.EchoHandler;
 import org.apache.http.localserver.RandomHandler;
-import org.apache.http.nio.client.methods.HttpAsyncMethods;
 import org.apache.http.nio.protocol.BasicAsyncRequestHandler;
-import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
-import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
 
 @RunWith(Parameterized.class)
 public class TestHttpAsyncPipelining extends AbstractAsyncTest {
@@ -174,55 +167,6 @@ public class TestHttpAsyncPipelining extends AbstractAsyncTest {
             final String s3 = EntityUtils.toString(response3.getEntity());
             Assert.assertNotNull(s3);
             Assert.assertEquals("all sorts of things", s3);
-        }
-
-    }
-
-    @Test @Ignore(value = "Fails on Windows")
-    public void testPipelinedRequestsUnexpectedConnectionClosure() throws Exception {
-        final HttpHost target = start();
-
-        for (int i = 0; i < 20; i++) {
-            final HttpAsyncRequestProducer p1 = HttpAsyncMethods.create(target, new HttpGet("/random/512"));
-            final HttpAsyncRequestProducer p2 = HttpAsyncMethods.create(target, new HttpGet("/pampa"));
-            final HttpAsyncRequestProducer p3 = HttpAsyncMethods.create(target, new HttpGet("/random/512"));
-            final HttpAsyncRequestProducer p4 = HttpAsyncMethods.create(target, new HttpGet("/random/512"));
-            final List<HttpAsyncRequestProducer> requestProducers = new ArrayList<HttpAsyncRequestProducer>();
-            requestProducers.add(p1);
-            requestProducers.add(p2);
-            requestProducers.add(p3);
-            requestProducers.add(p4);
-
-            final HttpAsyncResponseConsumer<HttpResponse> c1 = HttpAsyncMethods.createConsumer();
-            final HttpAsyncResponseConsumer<HttpResponse> c2 = HttpAsyncMethods.createConsumer();
-            final HttpAsyncResponseConsumer<HttpResponse> c3 = HttpAsyncMethods.createConsumer();
-            final HttpAsyncResponseConsumer<HttpResponse> c4 = HttpAsyncMethods.createConsumer();
-            final List<HttpAsyncResponseConsumer<HttpResponse>> responseConsumers = new ArrayList<HttpAsyncResponseConsumer<HttpResponse>>();
-            responseConsumers.add(c1);
-            responseConsumers.add(c2);
-            responseConsumers.add(c3);
-            responseConsumers.add(c4);
-
-            final Future<List<HttpResponse>> future = this.httpclient.execute(
-                    target,
-                    requestProducers,
-                    responseConsumers,
-                    null, null);
-            try {
-                future.get();
-            } catch (ExecutionException ex) {
-                final Throwable cause = ex.getCause();
-                Assert.assertNotNull(cause);
-                Assert.assertTrue(cause instanceof ConnectionClosedException);
-            }
-            Assert.assertTrue(c1.isDone());
-            Assert.assertNotNull(c1.getResult());
-            Assert.assertTrue(c2.isDone());
-            Assert.assertNotNull(c2.getResult());
-            Assert.assertTrue(c3.isDone());
-            Assert.assertNull(c3.getResult());
-            Assert.assertTrue(c4.isDone());
-            Assert.assertNull(c4.getResult());
         }
 
     }

--- a/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPrematureTermination.java
+++ b/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPrematureTermination.java
@@ -305,7 +305,7 @@ public class TestHttpAsyncPrematureTermination extends HttpAsyncTestBase {
         try {
             future.get();
             Assert.fail();
-        } catch (ExecutionException e) {
+        } catch (final ExecutionException e) {
             final Throwable cause = e.getCause();
             Assert.assertTrue("Unexpected cause: " + cause, cause instanceof IOException);
         }

--- a/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPrematureTermination.java
+++ b/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPrematureTermination.java
@@ -63,6 +63,7 @@ import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpCoreContext;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestHttpAsyncPrematureTermination extends HttpAsyncTestBase {
@@ -235,7 +236,7 @@ public class TestHttpAsyncPrematureTermination extends HttpAsyncTestBase {
         Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 
-    @Test
+    @Test @Ignore(value = "Fails on some Windows platforms")
     public void testConnectionRequestFailure() throws Exception {
         this.httpclient = HttpAsyncClients.custom()
                 .setConnectionManager(this.connMgr)

--- a/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPrematureTermination.java
+++ b/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPrematureTermination.java
@@ -27,7 +27,6 @@
 package org.apache.http.nio.client.integration;
 
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -306,7 +305,8 @@ public class TestHttpAsyncPrematureTermination extends HttpAsyncTestBase {
             future.get();
             Assert.fail();
         } catch (ExecutionException e) {
-            Assert.assertTrue(e.getCause() instanceof UnknownHostException);
+            final Throwable cause = e.getCause();
+            Assert.assertTrue("Unexpected cause: " + cause, cause instanceof IOException);
         }
         this.connMgr.shutdown(1000);
 

--- a/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPrematureTermination.java
+++ b/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPrematureTermination.java
@@ -242,7 +242,7 @@ public class TestHttpAsyncPrematureTermination extends HttpAsyncTestBase {
                 .build();
         this.httpclient.start();
 
-        final HttpGet get = new HttpGet("http://stuff.invalid/");
+        final HttpGet get = new HttpGet("http://0.0.0.0/");
         final HttpAsyncRequestProducer producer = HttpAsyncMethods.create(get);
 
         final AtomicBoolean closed = new AtomicBoolean(false);

--- a/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPrematureTermination.java
+++ b/httpasyncclient/src/test/java/org/apache/http/nio/client/integration/TestHttpAsyncPrematureTermination.java
@@ -27,6 +27,7 @@
 package org.apache.http.nio.client.integration;
 
 import java.io.IOException;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -382,7 +383,11 @@ public class TestHttpAsyncPrematureTermination extends HttpAsyncTestBase {
         };
 
         final Future<?> future = this.httpclient.execute(producer, consumer, null, null);
-        future.get();
+        try {
+            future.get();
+            Assert.fail("CancellationException expected");
+        } catch (final CancellationException expected) {
+        }
 
         connMgr.shutdown(1000);
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <modelVersion>4.0.0</modelVersion>
   <artifactId>httpcomponents-asyncclient</artifactId>
   <name>Apache HttpComponents AsyncClient</name>
-  <version>4.1.1-SNAPSHOT</version>
+  <version>4.2-alpha1-SNAPSHOT</version>
   <description>Apache components to build asynchronous client side HTTP services</description>
   <url>http://hc.apache.org/httpcomponents-asyncclient</url>
   <inceptionYear>2010</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <modelVersion>4.0.0</modelVersion>
   <artifactId>httpcomponents-asyncclient</artifactId>
   <name>Apache HttpComponents AsyncClient</name>
-  <version>4.2-alpha1-SNAPSHOT</version>
+  <version>4.1.1-SNAPSHOT</version>
   <description>Apache components to build asynchronous client side HTTP services</description>
   <url>http://hc.apache.org/httpcomponents-asyncclient</url>
   <inceptionYear>2010</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <httpcore.version>4.4.7</httpcore.version>
-    <httpclient.version>4.5.3</httpclient.version>
+    <httpcore.version>4.4.9</httpcore.version>
+    <httpclient.version>4.5.5</httpclient.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-io.version>2.4</commons-io.version>
     <junit.version>4.11</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <httpcore.version>4.4.1</httpcore.version>
+    <httpcore.version>4.4.3</httpcore.version>
     <httpclient.version>4.4.1</httpclient.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-io.version>2.4</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <modelVersion>4.0.0</modelVersion>
   <artifactId>httpcomponents-asyncclient</artifactId>
   <name>Apache HttpComponents AsyncClient</name>
-  <version>4.1.2-SNAPSHOT</version>
+  <version>4.1.3-SNAPSHOT</version>
   <description>Apache components to build asynchronous client side HTTP services</description>
   <url>http://hc.apache.org/httpcomponents-asyncclient</url>
   <inceptionYear>2010</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <httpcore.version>4.4.5</httpcore.version>
-    <httpclient.version>4.5.2</httpclient.version>
+    <httpcore.version>4.4.6</httpcore.version>
+    <httpclient.version>4.5.3</httpclient.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-io.version>2.4</commons-io.version>
     <junit.version>4.11</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <modelVersion>4.0.0</modelVersion>
   <artifactId>httpcomponents-asyncclient</artifactId>
   <name>Apache HttpComponents AsyncClient</name>
-  <version>4.1.1-SNAPSHOT</version>
+  <version>4.1.2-SNAPSHOT</version>
   <description>Apache components to build asynchronous client side HTTP services</description>
   <url>http://hc.apache.org/httpcomponents-asyncclient</url>
   <inceptionYear>2010</inceptionYear>
@@ -58,9 +58,9 @@
   </issueManagement>
 
   <scm>
-    <connection>scm:svn:https://svn.apache.org/repos/asf/httpcomponents/httpasyncclient/trunk</connection>
-    <developerConnection>scm:svn:https://svn.apache.org/repos/asf/httpcomponents/httpasyncclient/trunk</developerConnection>
-    <url>https://svn.apache.org/repos/asf/httpcomponents/httpasyncclient/trunk</url>
+    <connection>scm:svn:https://svn.apache.org/repos/asf/httpcomponents/httpasyncclient/branches/4.1.x</connection>
+    <developerConnection>scm:svn:https://svn.apache.org/repos/asf/httpcomponents/httpasyncclient/branches/4.1.x</developerConnection>
+    <url>https://svn.apache.org/repos/asf/httpcomponents/httpasyncclient/branches/4.1.x</url>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <modelVersion>4.0.0</modelVersion>
   <artifactId>httpcomponents-asyncclient</artifactId>
   <name>Apache HttpComponents AsyncClient</name>
-  <version>4.1.3-SNAPSHOT</version>
+  <version>4.1.4-SNAPSHOT</version>
   <description>Apache components to build asynchronous client side HTTP services</description>
   <url>http://hc.apache.org/httpcomponents-asyncclient</url>
   <inceptionYear>2010</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <httpcore.version>4.4.3</httpcore.version>
-    <httpclient.version>4.4.1</httpclient.version>
+    <httpclient.version>4.5.1</httpclient.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-io.version>2.4</commons-io.version>
     <junit.version>4.11</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <httpcore.version>4.4.6</httpcore.version>
+    <httpcore.version>4.4.7</httpcore.version>
     <httpclient.version>4.5.3</httpclient.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-io.version>2.4</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <httpcore.version>4.4.4</httpcore.version>
+    <httpcore.version>4.4.5</httpcore.version>
     <httpclient.version>4.5.1</httpclient.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-io.version>2.4</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <httpcore.version>4.4.5</httpcore.version>
-    <httpclient.version>4.5.1</httpclient.version>
+    <httpclient.version>4.5.2</httpclient.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-io.version>2.4</commons-io.version>
     <junit.version>4.11</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <httpcore.version>4.4.3</httpcore.version>
+    <httpcore.version>4.4.4</httpcore.version>
     <httpclient.version>4.5.1</httpclient.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-io.version>2.4</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>0.11</version>
+        <version>0.12</version>
         <executions>
           <execution>
             <phase>verify</phase>
@@ -279,6 +279,8 @@
         <configuration>
           <excludes>
             <exclude>src/test/resources/*.truststore</exclude>
+            <!-- Eclipse file not in the source repository -->
+            <exclude>**/.checkstyle</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
We use httpasyncclient as our core async RPC component, but we found a recovering issue a couple days ago.
it is the async client will be stoped because of I/O reactor shutdown when a service encounter a OOM problem, a few seconds later and after a FGC process, the service has been recovered, but the async client cannot be recovered. so the client cannot accept the request unless the service need to reboot.

the code is:
`               @Override
                public void run() {
                    try {
                        final IOEventDispatch ioEventDispatch = new InternalIODispatch(handler);
                        connmgr.execute(ioEventDispatch);
                    } catch (final Exception ex) {
                        log.error("I/O reactor terminated abnormally", ex);
                    } finally {
                        status.set(Status.STOPPED);
                    }
                }`
or by `close()` method.
so there is no way to set status from STOPPED to ACTIVE even by start().