### PR TITLE
fix a STOPPED to ACTIVE issue by start method

### DIFF
--- a/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/CloseableHttpAsyncClientBase.java
+++ b/httpasyncclient/src/main/java/org/apache/http/impl/nio/client/CloseableHttpAsyncClientBase.java
@@ -78,7 +78,7 @@ abstract class CloseableHttpAsyncClientBase extends CloseableHttpPipeliningClien
 
     @Override
     public void start() {
-        if (this.status.compareAndSet(Status.INACTIVE, Status.ACTIVE)) {
+        if (this.status.compareAndSet(Status.INACTIVE, Status.ACTIVE) || this.status.compareAndSet(Status.STOPPED, Status.ACTIVE)) {
             if (this.reactorThread != null) {
                 this.reactorThread.start();
             }


### PR DESCRIPTION
We use httpasyncclient as our core async RPC component, but we found a recovering issue a couple days ago.
it is the async client will be stoped because of I/O reactor shutdown when a service encounter a OOM problem, a few seconds later and after a FGC process, the service has been recovered, but the async client cannot be recovered. so the client cannot accept the request unless the service need to reboot.

the code is:
```java
@Override 
public void run() { 
    try { 
        final IOEventDispatch ioEventDispatch = new InternalIODispatch(handler); 
        connmgr.execute(ioEventDispatch);
     } catch (final Exception ex) { 
        log.error("I/O reactor terminated abnormally", ex);
     } finally {
        status.set(Status.STOPPED);
     }
 }
```
or by close() method.
so there is no way to set status from STOPPED to ACTIVE even by start().